### PR TITLE
Filenames in `TestFile`

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -152,6 +152,27 @@ mod tests {
         });
     }
 
+    #[test]
+    fn filenames_correct() {
+        let mut filenames = std::collections::BTreeSet::from([
+            "tests/testdata/args".to_string(),
+            "tests/testdata/multiline".to_string(),
+            "tests/testdata/nonewline".to_string(),
+            "tests/testdata/unicode".to_string(),
+            "tests/testdata/nested/nested_file".to_string(),
+        ]);
+
+        walk("tests/testdata", |f| {
+            assert!(
+                filenames.remove(&f.filename),
+                "could not find {}",
+                f.filename
+            );
+        });
+
+        assert!(filenames.is_empty(), "missing filenames: {:?}", filenames);
+    }
+
     #[tokio::test]
     async fn run_async() {
         walk_async("tests/testdata_async", |mut f| async move {


### PR DESCRIPTION
This PR makes `TestFile.filename` public.

Along the way, I refactored `TestFile::parse` to just return `Vec<Stanza>` rather than a `TestFile` with a `None` that immediately gets overwritten in `TestFile::new`.

I also added a test to ensure that the filenames we read out are correct.